### PR TITLE
#22 Update client link for Taube Pilates

### DIFF
--- a/src/lib/cms/pilates.md
+++ b/src/lib/cms/pilates.md
@@ -4,7 +4,7 @@ subtitles:
 theme: storm
 ---
 
-I am qualified in Pilates instruction, holding a Pilates Anatomy, Pilates Complete Mat Course, and Pilates Reformer Instructor Certification, from [Taube Pilates](https://www.taubepilatestraining.com/).
+I am qualified in Pilates instruction, holding a Pilates Anatomy, Pilates Complete Mat Course, and Pilates Reformer Instructor Certification, from [Taube Pilates](https://www.taubepilates.com/contact-Taube-Pilates-teacher-courses-online).
 
 ![](/src/lib/cms/media/3rd_party/taube.png)
 


### PR DESCRIPTION
#22 The Taube Pilates site has moved to a new domain. The link in the Pilates page is updated to go directly to the contact form of the new site.